### PR TITLE
fix(auth): gate profile redirect effect

### DIFF
--- a/web/app/settings/profile/page.tsx
+++ b/web/app/settings/profile/page.tsx
@@ -43,9 +43,16 @@ export default function EditProfile() {
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
   const [isUploadingBanner, setIsUploadingBanner] = useState(false);
 
-  // Redirect if not authenticated
-  if (!isAuthenticated && !isLoading) {
-    router.push("/");
+  const shouldRedirect = !isLoading && !isAuthenticated;
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      void router.push("/signin");
+    }
+  }, [router, shouldRedirect]);
+
+  if (shouldRedirect) {
+    return null;
   }
 
   // Initialize form data when profile loads


### PR DESCRIPTION
## Summary
- extract a reusable shouldRedirect guard for the profile settings page
- ensure the redirect effect awaits auth resolution before navigating

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69156f1fbaa08327aec3147bcafdc614)